### PR TITLE
Add support for text events

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,7 @@ const createServer = (feed, broadcast, sse, statsDb, origin = '*') => {
 
   // middlewares
   app.use(bodyParser.json())
+  app.use(bodyParser.text())
 
   const corsMiddleware = cors({
     origin,
@@ -53,6 +54,13 @@ const createServer = (feed, broadcast, sse, statsDb, origin = '*') => {
       if (!req.headers.origin) return next(createError(403))
       const { host, hostname } = url.parse(req.headers.origin)
       if (host !== origin || hostname !== origin) return next(createError(403))
+    }
+    if (req.body && typeof req.body === 'string') {
+      try {
+        req.body = JSON.parse(req.body)
+      } catch (e) {
+        return next(createError(400, 'error parsing body, should be type json or JSON parsable text.'))
+      }
     }
     const body = req.body
     if (!body.event) return next(createError(400, '"event" is required'))


### PR DESCRIPTION
Adds support for `navigator.sendBeacon` sent events. Currently Chrome limits the content types in `sendBeacon` for security reasons, so we cannot use json. For example, we are looking at this [client side library](https://github.com/yoshuawuyts/nanobeacon).

We want to track outbound links and the best way to do that is with `sendBeacon`. But json is not supported right now =(.

If this is merged we'll probably use [microanalytics](https://github.com/yoshuawuyts/microanalytics) on the client side but I can look into adding this to the fa client too!