### PR TITLE
Don't alias hypercore as hyperdrive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ As we said Fair Analytics is distributed.
 It's easily possible to replicate raw data.
 
 ```js
-const hyperdrive = require('hypercore')
+const hypercore = require('hypercore')
 const swarm = require('hyperdiscovery')
 const KEY = 'A FAIR ANALYTICS FEEED KEY'
 const LOCALPATH = './replicated.dataset'
 
-const feed = hyperdrive(LOCALPATH, KEY, {valueEncoding: 'json'})
+const feed = hypercore(LOCALPATH, KEY, {valueEncoding: 'json'})
 swarm(feed)
 
 feed.on('ready', () => {

--- a/lib/render-index.js
+++ b/lib/render-index.js
@@ -62,12 +62,12 @@ module.exports = key => {
   // useful when you want to store raw data to another machine
   // or when you want to process it somehow (like storing it to another database)
 
-  const hyperdrive = require('hypercore')
+  const hypercore = require('hypercore')
   const swarm = require('hyperdiscovery')
   const KEY = '${key}'
   const LOCALPATH = './replicated.dataset'
 
-  const feed = hyperdrive(LOCALPATH, KEY, {valueEncoding: 'json'})
+  const feed = hypercore(LOCALPATH, KEY, {valueEncoding: 'json'})
   swarm(feed)
 
   feed.on('ready', () => {


### PR DESCRIPTION
It's misleading to refer to the hypercore import as "hyperdrive" in the examples, since hyperdrive is a different module which depends on hypercore.